### PR TITLE
[Fix] TokenProvider 수정 

### DIFF
--- a/backend/src/main/java/com/pofo/backend/common/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/pofo/backend/common/security/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.pofo.backend.common.security;
+
+import com.pofo.backend.domain.user.join.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 필요한 경우 권한 로직을 구현 (예: ROLE_USER)
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        // 도메인 User 엔티티에 비밀번호 정보가 있다면 반환, 없으면 빈 문자열 등
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        // 예: email을 사용자 이름으로 사용
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/backend/src/main/java/com/pofo/backend/common/security/jwt/JwtSecurityConfig.java
+++ b/backend/src/main/java/com/pofo/backend/common/security/jwt/JwtSecurityConfig.java
@@ -19,7 +19,7 @@ public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurity
     private final TokenBlacklistService tokenBlacklistService; // 추가
 
     public void configure(HttpSecurity http) throws Exception {
-//        http.addFilterBefore(new JwtFilter("Authorization", tokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterBefore(new JwtFilter("Authorization", tokenProvider, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(new JwtFilter("Authorization", tokenProvider, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);
 
     }

--- a/backend/src/test/java/com/pofo/backend/common/security/jwt/JwtFilterTest.java
+++ b/backend/src/test/java/com/pofo/backend/common/security/jwt/JwtFilterTest.java
@@ -1,6 +1,7 @@
 package com.pofo.backend.common.security.jwt;
 
 
+import com.pofo.backend.common.service.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,6 +28,7 @@ class JwtFilterTest {
     private HttpServletResponse response;
     private FilterChain filterChain;
     private ValueOperations<String, String> valueOperations;
+    TokenBlacklistService tokenBlacklistService;
 
     @BeforeEach
     void setUp() {
@@ -35,7 +37,7 @@ class JwtFilterTest {
         valueOperations = mock(ValueOperations.class);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
-        jwtFilter = new JwtFilter("Authorization", tokenProvider, redisTemplate);
+        jwtFilter = new JwtFilter("Authorization", tokenProvider, tokenBlacklistService);
 
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);

--- a/backend/src/test/java/com/pofo/backend/common/security/jwt/UserReflectionTest.java
+++ b/backend/src/test/java/com/pofo/backend/common/security/jwt/UserReflectionTest.java
@@ -1,0 +1,24 @@
+package com.pofo.backend.common.security.jwt;
+
+import com.pofo.backend.domain.user.join.entity.User;
+import java.lang.reflect.Constructor;
+
+public class UserReflectionTest {
+    public static void main(String[] args) {
+        try {
+            // User 클래스의 Constructor 객체를 가져옵니다.
+            Constructor<User> constructor = User.class.getDeclaredConstructor();
+
+            // 생성자가 protected로 선언되어 있으므로 접근을 허용합니다.
+            constructor.setAccessible(true);
+
+            // User 인스턴스를 생성합니다.
+            User user = constructor.newInstance();
+
+            // 생성된 인스턴스를 사용하여 필요한 작업을 수행합니다.
+            System.out.println("User 인스턴스가 성공적으로 생성되었습니다: " + user);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
---
name: Pull Request 템플릿
about: PR 작성
---

## 🌿 반영 브랜치
<!-- 작업 브랜치 -> 병합 대상 브랜치를 작성해주세요. -->  
예: `feat/login -> dev`

## 🛠 작업 내용
<!-- 변경된 내용을 간단히 요약해주세요. -->  
- 기존에 단순히 토큰의 subject와 권한 정보를 가지고 새 User 객체(기본 UserDetails 구현체)를 생성하던 방식에서
- 실제 데이터베이스에 저장된 도메인 User 엔티티를 조회하여 이를 CustomUserDetails로 감싼 후 Authentication 객체를 구성하도록 변경함

## 🔗 관련 이슈
- getAuthentication() 메서드는 JWT 토큰의 subject와 권한 정보만을 사용해 기본적인 UserDetails 구현체를 생성. 
- 이 방식으로 생성된 객체는 기대하는 도메인 User 객체(또는 이를 감싼 CustomUserDetails)가 아니기 때문에, SecurityContextHolder에 올바른 객체가 주입되지 않고 결과적으로 컨트롤러에서  @AuthenticationPrincipal User user로 주입받을 때 null이 발생하는 문제

## 📂 추가 정보
<!-- 참고 자료나 관련 정보를 추가해주세요. -->  


## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어에게 요청하고 싶은 내용이 있다면 작성해주세요. -->  

