### PR TITLE
[Bugfix] security jwt subject 수정

### DIFF
--- a/backend/src/main/java/com/pofo/backend/common/security/jwt/TokenProvider.java
+++ b/backend/src/main/java/com/pofo/backend/common/security/jwt/TokenProvider.java
@@ -47,7 +47,7 @@ public class TokenProvider {
     private final AdminDetailsService adminDetailsService;
     private final UserDetailsService userDetailsService;
 
-    UsersRepository usersRepository;
+    private final UsersRepository usersRepository;
 
     @PostConstruct
     public void init() {
@@ -73,18 +73,21 @@ public class TokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String email = userDetails.getUsername();
+
         String accessToken = Jwts.builder()
-                .setSubject(authentication.getName())
-                .setExpiration(new Date(now + validationTime))
-                .claim(AUTHORIZATION_KEY, authorities)
-                .signWith(this.key, SignatureAlgorithm.HS512)
-                .compact();
+            .setSubject(email)
+            .setExpiration(new Date(now + validationTime))
+            .claim(AUTHORIZATION_KEY, authorities)
+            .signWith(this.key, SignatureAlgorithm.HS512)
+            .compact();
 
         String refreshToken = Jwts.builder()
-                .setSubject(authentication.getName())
-                .setExpiration(new Date(now + refreshTokenValidationTime))
-                .signWith(this.key, SignatureAlgorithm.HS512)
-                .compact();
+            .setSubject(email)
+            .setExpiration(new Date(now + refreshTokenValidationTime))
+            .signWith(this.key, SignatureAlgorithm.HS512)
+            .compact();
 
         log.info("Access Token 생성 완료");
         log.info("Refresh Token 생성 완료");

--- a/backend/src/main/java/com/pofo/backend/domain/resume/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/pofo/backend/domain/resume/resume/controller/ResumeController.java
@@ -1,6 +1,7 @@
 package com.pofo.backend.domain.resume.resume.controller;
 
 import com.pofo.backend.common.rsData.RsData;
+import com.pofo.backend.common.security.CustomUserDetails;
 import com.pofo.backend.domain.resume.resume.dto.request.ResumeCreateRequest;
 import com.pofo.backend.domain.resume.resume.dto.response.ResumeIdResponse;
 import com.pofo.backend.domain.resume.resume.dto.response.ResumeResponse;
@@ -25,7 +26,9 @@ public class ResumeController {
     @PostMapping("")
     public ResponseEntity<RsData<ResumeIdResponse>> createResume(
         @Valid @RequestBody ResumeCreateRequest resumeCreateRequest,
-        @AuthenticationPrincipal User user) {
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        User user = customUserDetails.getUser();
         Resume resume = resumeService.createResume(resumeCreateRequest, user);
         ResumeIdResponse response = new ResumeIdResponse(resume.getId());
         return ResponseEntity.ok(new RsData<>("200", "이력서 생성이 완료되었습니다.", response));
@@ -34,7 +37,9 @@ public class ResumeController {
     @PutMapping("/{resumeId}")
     public ResponseEntity<RsData<ResumeIdResponse>> updateResume(@PathVariable Long resumeId,
         @Valid @RequestBody ResumeCreateRequest resumeCreateRequest,
-        @AuthenticationPrincipal User user) {
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        User user = customUserDetails.getUser();
         Resume resume = resumeService.updateResume(resumeId, resumeCreateRequest, user);
         ResumeIdResponse response = new ResumeIdResponse(resume.getId());
         return ResponseEntity.ok(new RsData<>("200", "이력서 수정이 완료되었습니다.", response));
@@ -42,13 +47,16 @@ public class ResumeController {
 
     @DeleteMapping("/{resumeId}")
     public ResponseEntity<RsData<Object>> deleteResume(@PathVariable Long resumeId,
-        @AuthenticationPrincipal User user) {
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        User user = customUserDetails.getUser();
         resumeService.deleteResume(resumeId, user);
         return ResponseEntity.ok(new RsData<>("200", "이력서 삭제가 완료되었습니다."));
     }
 
     @GetMapping("")
-    public ResponseEntity<RsData<ResumeResponse>> getResume(@AuthenticationPrincipal User user) {
+    public ResponseEntity<RsData<ResumeResponse>> getResume(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        User user = customUserDetails.getUser();
         Resume resume = resumeService.getResumeByUser(user);
         ResumeResponse resumeResponse = resumeMapper.toResponse(resume);
         return ResponseEntity.ok(new RsData<>("200", "이력서 조회 성공", resumeResponse));

--- a/backend/src/main/java/com/pofo/backend/domain/user/login/service/UserLoginService.java
+++ b/backend/src/main/java/com/pofo/backend/domain/user/login/service/UserLoginService.java
@@ -1,6 +1,7 @@
 package com.pofo.backend.domain.user.login.service;
 
 import com.pofo.backend.common.exception.SocialLoginException;
+import com.pofo.backend.common.security.CustomUserDetails;
 import com.pofo.backend.common.security.dto.TokenDto;
 import com.pofo.backend.common.security.jwt.TokenProvider;
 import com.pofo.backend.domain.user.join.entity.Oauth;
@@ -303,10 +304,14 @@ public class UserLoginService {
     }
 
     private TokenDto authenticateUser(User userInfo) {
+        // User 객체를 CustomUserDetails로 감싸기
+        CustomUserDetails customUserDetails = new CustomUserDetails(userInfo);
+
         // Spring Security 사용 시 SecurityContext에 인증 정보 설정
         List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
         UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(userInfo, null, authorities);
+            new UsernamePasswordAuthenticationToken(customUserDetails, null, authorities);
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();


### PR DESCRIPTION
## 🌿 반영 브랜치
fix/security/customUserDetails -> develop

## 🛠 작업 내용
- jwt의 subject를 기존에 객체를 넘기고 있었어서 email로 수정
- 예시 사용법 resume 컨트롤러에 반영했습니다.
